### PR TITLE
Add license info to setup.py for registration on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
     include_package_data=True,
     data_files=data_files,
     install_requires=['pandas>0.24.0'],
+    license="AGPLv3",
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Cython",
@@ -96,6 +97,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering",
         "Environment :: Console",
+        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     ],
     description=short_description,
     author="Otto Fajardo",


### PR DESCRIPTION
Step 1 in solving Issue #52. Step 2 is the package owner running `python setup.py register` to update the metadata on PyPI.