### PR TITLE
`numpy 1.20` deprecation `np.float` fix

### DIFF
--- a/pyreadr/_pyreadr_writer.py
+++ b/pyreadr/_pyreadr_writer.py
@@ -21,7 +21,7 @@ int_types = {np.dtype('int32'), np.dtype('int16'), np.dtype('int8'), np.dtype('u
              np.int32, np.int16, np.int8, np.uint8, np.uint16}
 int_mixed_types = {pd.Int8Dtype(), pd.Int16Dtype(), pd.Int32Dtype(), pd.UInt8Dtype(), pd.UInt16Dtype()}
 float_types = {np.dtype('int64'), np.dtype('uint64'), np.dtype('uint32'), np.dtype('float'),
-               np.int64, np.uint64, np.uint32, np.float, pd.Int64Dtype(), pd.UInt32Dtype(), pd.UInt64Dtype(),
+               np.int64, np.uint64, np.uint32, float, pd.Int64Dtype(), pd.UInt32Dtype(), pd.UInt64Dtype(),
                pd.Float64Dtype(), pd.Float32Dtype()}
 datetime_types = {datetime.datetime, np.datetime64}
 


### PR DESCRIPTION
Fixing deprecation of `np.float` in `numpy >=1.20`