### PR TITLE
Fixing data frame index issue [ci skip]

### DIFF
--- a/pyreadr/_pyreadr_writer.py
+++ b/pyreadr/_pyreadr_writer.py
@@ -85,7 +85,7 @@ def get_pyreadr_column_types(df):
                 if col_type in int_mixed_types:
                     result[col_name] = "INTEGER"
                     continue
-                curtype = type(df[col_name][0])
+                curtype = type(df[col_name].iloc[0])
                 equal = np.array(df[col_name].apply(lambda x: type(x) == curtype))
                 if not np.all(equal):
                     result[col_name] = "OBJECT"


### PR DESCRIPTION
If the data frame doesn't have an index == 0 it will raise an error.

Running the command pyreadr.write_rdata for the whole data frame will probably work but if the data frame is filtered it raise. This can't be avoided if a df.reset_index() is performed beforehand but could take some time until the developer discovers the issue.